### PR TITLE
Allow to set annotations for services

### DIFF
--- a/charts/netris-controller/templates/web-service-frontend.yaml
+++ b/charts/netris-controller/templates/web-service-frontend.yaml
@@ -86,6 +86,10 @@ metadata:
   labels:
     {{- include "netris-controller.labels" . | nindent 4 }}
     {{- printf "%s-%s" (include "netris-controller.selectorLabels" .) $microservicename | nindent 4 }}
+  {{- with (index .Values $microservicename).service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ (index .Values $microservicename).service.type }}
   ports:

--- a/charts/netris-controller/values.yaml
+++ b/charts/netris-controller/values.yaml
@@ -91,7 +91,7 @@ web-service-backend:
     type: ClusterIP
     port: 80
     name: http
-
+    annotations: {}
 
   autoscaling:
     enabled: false
@@ -118,6 +118,7 @@ web-service-frontend:
     type: ClusterIP
     port: 80
     name: http
+    annotations: {}
 
   autoscaling:
     enabled: false
@@ -142,6 +143,7 @@ grpc:
     type: ClusterIP
     port: 443
     name: grpc
+    annotations: {}
 
   autoscaling:
     enabled: false
@@ -168,6 +170,7 @@ telescope:
     name: ws
     securePort: 443
     securePortName: wss
+    annotations: {}
 
   autoscaling:
     enabled: false
@@ -211,6 +214,7 @@ web-session-generator:
     type: ClusterIP
     port: 80
     name: http
+    annotations: {}
 
   autoscaling:
     enabled: false
@@ -319,7 +323,7 @@ haproxy:
   service:
     type: LoadBalancer
     externalTrafficPolicy: Local
-
+    annotations: {}
 
 ## Using default values from https://github.com/kiwigrid/helm-charts/tree/master/charts/graphite/values.yaml
 graphite:


### PR DESCRIPTION
This is useful when we want to use pre-allocated IP. For example metallb allows to set it via annotation metallb.io/loadBalancerIPs