### PR TITLE
Allow to set registry globally

### DIFF
--- a/charts/netris-controller/templates/equinix-metal-agent.yaml
+++ b/charts/netris-controller/templates/equinix-metal-agent.yaml
@@ -32,7 +32,7 @@ spec:
       - name: init-wait-webapp
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
-        image: alpine:3.11
+        image: "{{ .Values.registry }}alpine:3.11"
         command:
           - sh
           - -c
@@ -40,7 +40,7 @@ spec:
       - name: init-wait-websession
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
-        image: alpine:3.11
+        image: "{{ .Values.registry }}alpine:3.11"
         command:
           - sh
           - -c

--- a/charts/netris-controller/templates/equinix-metal-agent.yaml
+++ b/charts/netris-controller/templates/equinix-metal-agent.yaml
@@ -49,7 +49,7 @@ spec:
         - name: {{ printf "%s-%s" .Chart.Name $microservicename }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ (index .Values $microservicename).image.repository }}:{{ (index .Values $microservicename).image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.registry }}{{ (index .Values $microservicename).image.repository }}:{{ (index .Values $microservicename).image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ (index .Values $microservicename).image.pullPolicy }}
           command: ['/app/servicebin']
           env:

--- a/charts/netris-controller/templates/grpc.yaml
+++ b/charts/netris-controller/templates/grpc.yaml
@@ -43,7 +43,7 @@ spec:
         - name: {{ printf "%s-%s" .Chart.Name $microservicename }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ (index .Values $microservicename).image.repository }}:{{ (index .Values $microservicename).image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.registry }}{{ (index .Values $microservicename).image.repository }}:{{ (index .Values $microservicename).image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ (index .Values $microservicename).image.pullPolicy }}
           env:
             - name: GRPC_AUTH_KEYS

--- a/charts/netris-controller/templates/grpc.yaml
+++ b/charts/netris-controller/templates/grpc.yaml
@@ -34,7 +34,7 @@ spec:
       - name: init-wait-mariadb
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
-        image: alpine:3.11
+        image: "{{ .Values.registry }}alpine:3.11"
         command:
           - sh
           - -c

--- a/charts/netris-controller/templates/migration.yaml
+++ b/charts/netris-controller/templates/migration.yaml
@@ -43,7 +43,7 @@ spec:
         - name: {{ printf "%s-%s" .Chart.Name $microservicename }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ (index .Values $microservicename).image.repository }}:{{ (index .Values $microservicename).image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.registry }}{{ (index .Values $microservicename).image.repository }}:{{ (index .Values $microservicename).image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ (index .Values $microservicename).image.pullPolicy }}
           env:
             - name: DB_NAME

--- a/charts/netris-controller/templates/migration.yaml
+++ b/charts/netris-controller/templates/migration.yaml
@@ -34,7 +34,7 @@ spec:
       - name: init-wait-mariadb
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
-        image: alpine:3.11
+        image: "{{ .Values.registry }}alpine:3.11"
         command:
           - sh
           - -c

--- a/charts/netris-controller/templates/phoenixnap-bmc-agent.yaml
+++ b/charts/netris-controller/templates/phoenixnap-bmc-agent.yaml
@@ -32,7 +32,7 @@ spec:
       - name: init-wait-webapp
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
-        image: alpine:3.11
+        image: "{{ .Values.registry }}alpine:3.11"
         command:
           - sh
           - -c
@@ -40,7 +40,7 @@ spec:
       - name: init-wait-websession
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
-        image: alpine:3.11
+        image: "{{ .Values.registry }}alpine:3.11"
         command:
           - sh
           - -c

--- a/charts/netris-controller/templates/phoenixnap-bmc-agent.yaml
+++ b/charts/netris-controller/templates/phoenixnap-bmc-agent.yaml
@@ -49,7 +49,7 @@ spec:
         - name: {{ printf "%s-%s" .Chart.Name $microservicename }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ (index .Values $microservicename).image.repository }}:{{ (index .Values $microservicename).image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.registry }}{{ (index .Values $microservicename).image.repository }}:{{ (index .Values $microservicename).image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ (index .Values $microservicename).image.pullPolicy }}
           command: ['/app/servicebin']
           env:

--- a/charts/netris-controller/templates/telescope-notifier.yaml
+++ b/charts/netris-controller/templates/telescope-notifier.yaml
@@ -34,7 +34,7 @@ spec:
       - name: init-wait-mariadb
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
-        image: alpine:3.11
+        image: "{{ .Values.registry }}alpine:3.11"
         command:
           - sh
           - -c

--- a/charts/netris-controller/templates/telescope-notifier.yaml
+++ b/charts/netris-controller/templates/telescope-notifier.yaml
@@ -43,7 +43,7 @@ spec:
         - name: {{ printf "%s-%s" .Chart.Name $microservicename }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ (index .Values $microservicename).image.repository }}:{{ (index .Values $microservicename).image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.registry }}{{ (index .Values $microservicename).image.repository }}:{{ (index .Values $microservicename).image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ (index .Values $microservicename).image.pullPolicy }}
           command: ['/app/servicebin', '-c', '/app/config/telescope-notifier.conf']
           resources:

--- a/charts/netris-controller/templates/telescope.yaml
+++ b/charts/netris-controller/templates/telescope.yaml
@@ -51,7 +51,7 @@ spec:
         - name: {{ printf "%s-%s" .Chart.Name $microservicename }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ (index .Values $microservicename).image.repository }}:{{ (index .Values $microservicename).image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.registry }}{{ (index .Values $microservicename).image.repository }}:{{ (index .Values $microservicename).image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ (index .Values $microservicename).image.pullPolicy }}
           env:
             - name: GRPC_AUTH_KEYS

--- a/charts/netris-controller/templates/telescope.yaml
+++ b/charts/netris-controller/templates/telescope.yaml
@@ -34,7 +34,7 @@ spec:
       - name: init-wait-mariadb
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
-        image: alpine:3.11
+        image: "{{ .Values.registry }}alpine:3.11"
         command:
           - sh
           - -c
@@ -42,7 +42,7 @@ spec:
       - name: init-wait-grpc
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
-        image: alpine:3.11
+        image: "{{ .Values.registry }}alpine:3.11"
         command:
           - sh
           - -c

--- a/charts/netris-controller/templates/web-service-backend.yaml
+++ b/charts/netris-controller/templates/web-service-backend.yaml
@@ -34,7 +34,7 @@ spec:
       - name: init-wait-mariadb
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
-        image: alpine:3.11
+        image: "{{ .Values.registry }}alpine:3.11"
         command:
           - sh
           - -c

--- a/charts/netris-controller/templates/web-service-backend.yaml
+++ b/charts/netris-controller/templates/web-service-backend.yaml
@@ -43,7 +43,7 @@ spec:
         - name: {{ printf "%s-%s" .Chart.Name $microservicename }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ (index .Values $microservicename).image.repository }}:{{ (index .Values $microservicename).image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.registry }}{{ (index .Values $microservicename).image.repository }}:{{ (index .Values $microservicename).image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ (index .Values $microservicename).image.pullPolicy }}
           env:
             - name: CONDUCTOR_LISTEN_PORT

--- a/charts/netris-controller/templates/web-service-frontend.yaml
+++ b/charts/netris-controller/templates/web-service-frontend.yaml
@@ -34,7 +34,7 @@ spec:
       - name: init-wait-backend
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
-        image: alpine:3.11
+        image: "{{ .Values.registry }}alpine:3.11"
         command:
           - sh
           - -c

--- a/charts/netris-controller/templates/web-service-frontend.yaml
+++ b/charts/netris-controller/templates/web-service-frontend.yaml
@@ -43,7 +43,7 @@ spec:
         - name: {{ printf "%s-%s" .Chart.Name $microservicename }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ (index .Values $microservicename).image.repository }}:{{ (index .Values $microservicename).image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.registry }}{{ (index .Values $microservicename).image.repository }}:{{ (index .Values $microservicename).image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ (index .Values $microservicename).image.pullPolicy }}
           ports:
             - name: {{ (index .Values $microservicename).service.name }}

--- a/charts/netris-controller/templates/web-session-generator.yaml
+++ b/charts/netris-controller/templates/web-session-generator.yaml
@@ -34,7 +34,7 @@ spec:
       - name: init-wait-mariadb
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
-        image: alpine:3.11
+        image: "{{ .Values.registry }}alpine:3.11"
         command:
           - sh
           - -c

--- a/charts/netris-controller/templates/web-session-generator.yaml
+++ b/charts/netris-controller/templates/web-session-generator.yaml
@@ -43,7 +43,7 @@ spec:
         - name: {{ printf "%s-%s" .Chart.Name $microservicename }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ (index .Values $microservicename).image.repository }}:{{ (index .Values $microservicename).image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.registry }}{{ (index .Values $microservicename).image.repository }}:{{ (index .Values $microservicename).image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ (index .Values $microservicename).image.pullPolicy }}
           command: ['/app/servicebin']
           ports:

--- a/charts/netris-controller/values.yaml
+++ b/charts/netris-controller/values.yaml
@@ -2,6 +2,10 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# Registry URL for container images (e.g., "docker.io/" or "registry.example.com/")
+# Leave empty to use default registry
+registry: ""
+
 nameOverride: ""
 fullnameOverride: ""
 

--- a/charts/netris-operator/templates/deployment.yaml
+++ b/charts/netris-operator/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
           - --enable-leader-election
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.registry }}{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/netris-operator/values.yaml
+++ b/charts/netris-operator/values.yaml
@@ -2,6 +2,10 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# Registry URL for container images (e.g., "docker.io/" or "registry.example.com/")
+# Leave empty to use default registry
+registry: ""
+
 replicaCount: 1
 
 image:


### PR DESCRIPTION
Images are stored on dockerhub but for production we need to use proxy or internal registry.
This patch adds Values.registry variable to store full path to docker registry.